### PR TITLE
fix(popup): delete EventListener

### DIFF
--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -275,38 +275,38 @@ export default {
         }
       }
     },
-    initListeners() {
+       initListeners() {
       if (this.triggerEl) {
         if (this.trigger === 'hover') {
-          this.on(this.triggerEl, 'mouseenter', this.show)
-          this.on(this.triggerEl, 'mouseleave', this.hide)
+          this.triggerEl.addEventListener('mouseenter', this.show);
+          this.triggerEl.addEventListener('mouseleave', this.hide);
         } else if (this.trigger === 'focus') {
-          this.on(this.triggerEl, 'focus', this.show)
-          this.on(this.triggerEl, 'blur', this.hide)
+          this.triggerEl.addEventListener('focus', this.show);
+          this.triggerEl.addEventListener('blur', this.hide);
         } else if (this.trigger === 'hover-focus') {
-          this.on(this.triggerEl, 'mouseenter', this.handleAuto)
-          this.on(this.triggerEl, 'mouseleave', this.handleAuto)
-          this.on(this.triggerEl, 'focus', this.handleAuto)
-          this.on(this.triggerEl, 'blur', this.handleAuto)
+          this.triggerEl.addEventListener('mouseenter', this.handleAuto);
+          this.triggerEl.addEventListener('mouseleave', this.handleAuto);
+          this.triggerEl.addEventListener('focus', this.handleAuto);
+          this.triggerEl.addEventListener('blur', this.handleAuto);
         } else if (this.trigger === 'click' || this.trigger === 'outside-click') {
-          this.on(this.triggerEl, 'click', this.toggle)
+          this.triggerEl.addEventListener('click', this.toggle);
         }
       }
-      this.on(window, 'click', this.windowClicked)
+      window.addEventListener('click', this.windowClicked);
     },
-    clearListeners() {
+   clearListeners() {
       if (this.triggerEl) {
-        this.off(this.triggerEl, 'focus', this.show)
-        this.off(this.triggerEl, 'blur', this.hide)
-        this.off(this.triggerEl, 'mouseenter', this.show)
-        this.off(this.triggerEl, 'mouseleave', this.hide)
-        this.off(this.triggerEl, 'click', this.toggle)
-        this.off(this.triggerEl, 'mouseenter', this.handleAuto)
-        this.off(this.triggerEl, 'mouseleave', this.handleAuto)
-        this.off(this.triggerEl, 'focus', this.handleAuto)
-        this.off(this.triggerEl, 'blur', this.handleAuto)
+        this.triggerEl.removeEventListener('focus', this.show);
+        this.triggerEl.removeEventListener('blur', this.hide);
+        this.triggerEl.removeEventListener('mouseenter', this.show);
+        this.triggerEl.removeEventListener('mouseleave', this.hide);
+        this.triggerEl.removeEventListener('click', this.toggle);
+        this.triggerEl.removeEventListener('mouseenter', this.handleAuto);
+        this.triggerEl.removeEventListener('mouseleave', this.handleAuto);
+        this.triggerEl.removeEventListener('focus', this.handleAuto);
+        this.triggerEl.removeEventListener('blur', this.handleAuto);
       }
-      this.off(window, 'click', this.windowClicked)
+      window('click', this.windowClicked);
       this.clearTimeouts();
     },
     clearTimeouts() {
@@ -332,13 +332,6 @@ export default {
       if (popup) {
         setTooltipPosition(popup, this.triggerEl, this.placement, this.autoPlacement, this.appendTo, this.viewport);
       }
-    },
-    off(element, event, handler) {
-      element.removeEventListener(event, handler)
-    },
-
-    on(element, event, handler) {
-      element.addEventListener(event, handler)
     },
     hideOnLeave() {
       if (this.trigger === 'hover' || (this.trigger === 'hover-focus' && !this.triggerEl.matches(':focus'))) {

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -246,7 +246,7 @@ export default {
       }
     });
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.clearListeners();
     if (this.$refs.popup && this.$refs.popup.parentNode) {
       this.$refs.popup.parentNode.removeChild(this.$refs.popup);
@@ -278,35 +278,35 @@ export default {
     initListeners() {
       if (this.triggerEl) {
         if (this.trigger === 'hover') {
-          this.triggerEl.addEventListener('mouseenter', this.show);
-          this.triggerEl.addEventListener('mouseleave', this.hide);
+          this.on(this.triggerEl, 'mouseenter', this.show)
+          this.on(this.triggerEl, 'mouseleave', this.hide)
         } else if (this.trigger === 'focus') {
-          this.triggerEl.addEventListener('focus', this.show);
-          this.triggerEl.addEventListener('blur', this.hide);
+          this.on(this.triggerEl, 'focus', this.show)
+          this.on(this.triggerEl, 'blur', this.hide)
         } else if (this.trigger === 'hover-focus') {
-          this.triggerEl.addEventListener('mouseenter', this.handleAuto);
-          this.triggerEl.addEventListener('mouseleave', this.handleAuto);
-          this.triggerEl.addEventListener('focus', this.handleAuto);
-          this.triggerEl.addEventListener('blur', this.handleAuto);
+          this.on(this.triggerEl, 'mouseenter', this.handleAuto)
+          this.on(this.triggerEl, 'mouseleave', this.handleAuto)
+          this.on(this.triggerEl, 'focus', this.handleAuto)
+          this.on(this.triggerEl, 'blur', this.handleAuto)
         } else if (this.trigger === 'click' || this.trigger === 'outside-click') {
-          this.triggerEl.addEventListener('click', this.toggle);
+          this.on(this.triggerEl, 'click', this.toggle)
         }
       }
-      window.addEventListener('click', this.windowClicked);
+      this.on(window, 'click', this.windowClicked)
     },
     clearListeners() {
       if (this.triggerEl) {
-        this.triggerEl('focus', this.show);
-        this.triggerEl('blur', this.hide);
-        this.triggerEl('mouseenter', this.show);
-        this.triggerEl('mouseleave', this.hide);
-        this.triggerEl('click', this.toggle);
-        this.triggerEl('mouseenter', this.handleAuto);
-        this.triggerEl('mouseleave', this.handleAuto);
-        this.triggerEl('focus', this.handleAuto);
-        this.triggerEl('blur', this.handleAuto);
+        this.off(this.triggerEl, 'focus', this.show)
+        this.off(this.triggerEl, 'blur', this.hide)
+        this.off(this.triggerEl, 'mouseenter', this.show)
+        this.off(this.triggerEl, 'mouseleave', this.hide)
+        this.off(this.triggerEl, 'click', this.toggle)
+        this.off(this.triggerEl, 'mouseenter', this.handleAuto)
+        this.off(this.triggerEl, 'mouseleave', this.handleAuto)
+        this.off(this.triggerEl, 'focus', this.handleAuto)
+        this.off(this.triggerEl, 'blur', this.handleAuto)
       }
-      window('click', this.windowClicked);
+      this.off(window, 'click', this.windowClicked)
       this.clearTimeouts();
     },
     clearTimeouts() {
@@ -332,6 +332,13 @@ export default {
       if (popup) {
         setTooltipPosition(popup, this.triggerEl, this.placement, this.autoPlacement, this.appendTo, this.viewport);
       }
+    },
+    off(element, event, handler) {
+      element.removeEventListener(event, handler)
+    },
+
+    on(element, event, handler) {
+      element.addEventListener(event, handler)
     },
     hideOnLeave() {
       if (this.trigger === 'hover' || (this.trigger === 'hover-focus' && !this.triggerEl.matches(':focus'))) {

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -275,7 +275,7 @@ export default {
         }
       }
     },
-       initListeners() {
+    initListeners() {
       if (this.triggerEl) {
         if (this.trigger === 'hover') {
           this.triggerEl.addEventListener('mouseenter', this.show);
@@ -294,7 +294,7 @@ export default {
       }
       window.addEventListener('click', this.windowClicked);
     },
-   clearListeners() {
+    clearListeners() {
       if (this.triggerEl) {
         this.triggerEl.removeEventListener('focus', this.show);
         this.triggerEl.removeEventListener('blur', this.hide);

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -306,7 +306,7 @@ export default {
         this.triggerEl.removeEventListener('focus', this.handleAuto);
         this.triggerEl.removeEventListener('blur', this.handleAuto);
       }
-      window('click', this.windowClicked);
+      window.removeEventListener('click', this.windowClicked);
       this.clearTimeouts();
     },
     clearTimeouts() {


### PR DESCRIPTION
This MR aims to fix the popup mixin. Currently there is a bug with creating and removing the eventListeners. This leads to the error `this.triggerlEl is not a function`. This MR relies on the official uiv implementation