### PR TITLE
fix(toolbar): only render slot container if there are filters

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -8,9 +8,9 @@
   >
     <div class="col-sm-12">
       <form class="toolbar-pf-actions" :class="{'no-filter-results': !showResultFilter}" @submit="$event.preventDefault()">
-        <div class="filter-pf filter-fields form-group toolbar-pf-filter">
+        <div v-if="showFilter" class="filter-pf filter-fields form-group toolbar-pf-filter">
           <slot name="filter">
-            <pf-filter-fields v-if="showFilter" :fields="filterFields" @filter="addFilter" />
+            <pf-filter-fields :fields="filterFields" @filter="addFilter" />
           </slot>
         </div>
         <div v-if="showSorter || showColumnPicker" class="form-group">

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -8,9 +8,9 @@
   >
     <div class="col-sm-12">
       <form class="toolbar-pf-actions" :class="{'no-filter-results': !showResultFilter}" @submit="$event.preventDefault()">
-        <div v-if="showFilter" class="filter-pf filter-fields form-group toolbar-pf-filter">
+        <div v-if="showFilter || $slots.filter" class="filter-pf filter-fields form-group toolbar-pf-filter">
           <slot name="filter">
-            <pf-filter-fields :fields="filterFields" @filter="addFilter" />
+            <pf-filter-fields v-if="showFilter" :fields="filterFields" @filter="addFilter" />
           </slot>
         </div>
         <div v-if="showSorter || showColumnPicker" class="form-group">

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -10,7 +10,7 @@
       <form class="toolbar-pf-actions" :class="{'no-filter-results': !showResultFilter}" @submit="$event.preventDefault()">
         <div v-if="showFilter || $slots.filter" class="filter-pf filter-fields form-group toolbar-pf-filter">
           <slot name="filter">
-            <pf-filter-fields v-if="showFilter" :fields="filterFields" @filter="addFilter" />
+            <pf-filter-fields :fields="filterFields" @filter="addFilter" />
           </slot>
         </div>
         <div v-if="showSorter || showColumnPicker" class="form-group">


### PR DESCRIPTION
This fix prevents the div (for the slot) to be rendered if there are no filters  (!showFilters). Having the condition inside the slot caused an empty, weird looking column to be rendered.