### PR TITLE
fix(modal): use correct teleport target

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport :to="modalsTarget || 'body'">
+  <teleport :to="modalsTarget.value || 'body'">
     <transition-group name="pf-drop-fade">
       <div v-if="show" key="modal" v-bind="$attrs" class="modal" role="dialog" @click="clickOutside">
         <div ref="dialog" class="modal-dialog">


### PR DESCRIPTION
Hello again! 

It seems like that the injected `modelTarget` doesn't contain the expected ref. Please rethink / check before merging :) 