### PR TITLE
fix(select): don't disable select input by default

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -9,7 +9,7 @@
     <component :is="btnType" ref="btn" :type="button ? 'button' : null" class="dropdown-toggle" :class="{
                  'btn btn-default': button,
                  'form-control': !button,
-               }" :tabindex="tabindex" v-bind="attributes" :readonly="readonly" role="button" :aria-expanded="show.toString()"
+               }" :tabindex="tabindex" :disabled="disabled || null" :readonly="readonly" role="button" :aria-expanded="show.toString()"
                @blur="canSearch ? null : close"
                @click="toggle"
                @keydown.esc.stop.prevent="close"
@@ -107,14 +107,6 @@ export default {
 
     btnType() {
       return this.button ? 'button' : 'div';
-    },
-    
-    attributes() {
-      const attrs = Object.assign({}, this.$attrs);
-      if (this.disabled) {
-        attrs.disabled = "disabled";
-      }
-      return attrs;
     },
   },
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -9,7 +9,7 @@
     <component :is="btnType" ref="btn" :type="button ? 'button' : null" class="dropdown-toggle" :class="{
                  'btn btn-default': button,
                  'form-control': !button,
-               }" :tabindex="tabindex" :disabled="disabled" :readonly="readonly" role="button" :aria-expanded="show.toString()"
+               }" :tabindex="tabindex" v-bind="attributes" :readonly="readonly" role="button" :aria-expanded="show.toString()"
                @blur="canSearch ? null : close"
                @click="toggle"
                @keydown.esc.stop.prevent="close"
@@ -107,6 +107,14 @@ export default {
 
     btnType() {
       return this.button ? 'button' : 'div';
+    },
+    
+    attributes() {
+      const attrs = Object.assign({}, this.$attrs);
+      if (this.disabled) {
+        attrs.disabled = "disabled";
+      }
+      return attrs;
     },
   },
 


### PR DESCRIPTION
It seems like there were some (undocumented) changes in Vue3 with the rendering of html attributes.

In Vue2 `<div :disabled="isDisabled" />` (where isDisabled = false) would render to: `<div />`

In Vue 3 the same line leads to `<div disabled="false" />` (which is no valid html). 

This causes all selects to be disabled, no matter what. I will go ahead and check if there are other cases where this issue occurs, but without any further checking, it seems to be the only place.