### PR TITLE
fix(tooltip): cleanup containers properly

### DIFF
--- a/src/directives/tooltip.ts
+++ b/src/directives/tooltip.ts
@@ -16,7 +16,7 @@ function getContainer() {
   return cont;
 }
 
-function bind(el: (Element | DefineComponent) & { 'v-tooltip'?: App }, binding: DirectiveBinding) {
+function bind(el: (Element | DefineComponent) & { 'v-tooltip'?: App, container: HTMLElement }, binding: DirectiveBinding) {
   unbind(el);
   const options = [];
   for (const key in binding.modifiers) {
@@ -42,11 +42,6 @@ function bind(el: (Element | DefineComponent) & { 'v-tooltip'?: App }, binding: 
 
   const container = getContainer();
   const vm = createApp(defineComponent({
-    data() {
-      return {
-        container,
-      };
-    },
     render() {
       return h(Tooltip as unknown as DefineComponent, {
         target: el,
@@ -61,25 +56,26 @@ function bind(el: (Element | DefineComponent) & { 'v-tooltip'?: App }, binding: 
     },
   }));
   vm.mount(container);
+  el.container = container;
   el['v-tooltip'] = vm;
 }
 
-function unbind(el: (Element | DefineComponent) & { 'v-tooltip'?: App }) {
+function unbind(el: (Element | DefineComponent) & { 'v-tooltip'?: App, container: HTMLElement }) {
   const vm = el['v-tooltip'];
   if (!vm) {
     return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const container = (vm as any)?.container;
+  const { container } = el;
   if (container instanceof HTMLElement) {
     document.documentElement.removeChild(container);
   }
   vm.unmount();
   delete el['v-tooltip'];
+  delete el.container;
 }
 
-function updated(el: (Element | DefineComponent) & { 'v-tooltip'?: App }, binding: DirectiveBinding) {
+function updated(el: (Element | DefineComponent) & { 'v-tooltip'?: App, container: HTMLElement }, binding: DirectiveBinding) {
   if (binding.value !== binding.oldValue) {
     bind(el, binding);
   }


### PR DESCRIPTION
This fixes an issue that was kinda teased in https://github.com/mtorromeo/vue-patternfly3/issues/37.

After a bit investigation it turned out that the app containers were never destroyed when unmounting / updating the directive. With many updates this will lead to quite some abandoned DOM nodes as you can imagine.

The reason for that is that the check in the unbind hook will fail, because the data of the vm cannot be accessed.

```
const container = (vm as any)?.container;
if (container instanceof HTMLElement) {
 document.documentElement.removeChild(container);
}
```

This happens because `createApp` will create an application instance that **doesn't** hold data. The data will only be available in the component public instance which is created by mounting the app instance (`app.mount()`) .

So basically we could either pass around the public instance (not worth it imo), or pass the container in the el as done within this PR.